### PR TITLE
Fix mutation during set iteration in graph traversal

### DIFF
--- a/app/graph_rag.py
+++ b/app/graph_rag.py
@@ -145,17 +145,22 @@ class GraphRAG:
           
           context += "\n"
       # Traverse the graph to add related tables
-      for related_table in related_to_add:
-        if related_table not in nodes_added_to_context:
-            # get the doc of the related table            
-            context += f"- Table: {related_table}\n"
-            context += f"  Columns: {', '.join(self.graph.nodes[related_table]['columns'])}\n"
-            context += f"  Common values: {self.graph.nodes[related_table]['frequent_values']}\n"
-            related_tables = list(self.graph.neighbors(node))
-            context += f"  Related tables: {', '.join(related_tables)}\n\n"
-            nodes_added_to_context.add(related_table)
-            related_to_add.remove(related_table)
-            for table in related_tables:
-                if table not in nodes_added_to_context:
-                    related_to_add.add(table)
+      while related_to_add:
+          related_table = related_to_add.pop()
+          if related_table in nodes_added_to_context:
+              continue
+
+          context += f"- Table: {related_table}\n"
+          context += f"  Columns: {', '.join(self.graph.nodes[related_table]['columns'])}\n"
+          context += f"  Common values: {self.graph.nodes[related_table]['frequent_values']}\n"
+
+          related_tables = list(self.graph.neighbors(related_table))
+          context += f"  Related tables: {', '.join(related_tables)}\n\n"
+
+          nodes_added_to_context.add(related_table)
+
+          for table in related_tables:
+              if table not in nodes_added_to_context:
+                  related_to_add.add(table)
+
       return context

--- a/tests/test_graph_rag.py
+++ b/tests/test_graph_rag.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import networkx as nx
+from collections import namedtuple
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app.graph_rag import GraphRAG
+
+Document = namedtuple('Document', ['page_content', 'metadata'])
+
+
+class DummyVectorStore:
+    def similarity_search(self, query, k=5):
+        return [
+            Document(
+                page_content="{'foo': 'bar'}",
+                metadata={'db': 'db', 'table': 'table1', 'columns': ['col1']}
+            )
+        ]
+
+
+def test_get_context_includes_related_tables():
+    rag = GraphRAG()
+    rag.vector_store = DummyVectorStore()
+
+    rag.graph = nx.Graph()
+    rag.graph.add_node('db.table1', columns=['col1'], frequent_values="{'foo': 'bar'}")
+    rag.graph.add_node('db.table2', columns=['col2'], frequent_values="{'baz': 'qux'}")
+    rag.graph.add_edge('db.table1', 'db.table2', weight=0.5)
+
+    context = rag.get_context('query')
+
+    assert 'Table: db.table1' in context
+    assert 'Table: db.table2' in context


### PR DESCRIPTION
## Summary
- Avoid modifying `related_to_add` while iterating in `GraphRAG.get_context`
- Correct neighbor lookup when expanding related tables
- Realign `return` statement to finish traversal and prevent indentation errors
- Add unit test ensuring related tables are included in the context

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e3a48bc6c8324adcf74e688704c18